### PR TITLE
convert_cb_archive_to_pdf: Fix output filename (remove generic `cb*` extension)

### DIFF
--- a/convert_cb_archive_to_pdf
+++ b/convert_cb_archive_to_pdf
@@ -60,7 +60,7 @@ function check_input_files {
 }
 
 function prepare_output_filename {
-  v_output_file=${v_input_file%.cbr}.pdf
+  v_output_file=${v_input_file%.cb*}.pdf
 }
 
 function create_temp_dir {


### PR DESCRIPTION
It hadn't been updated for `cbz`; now it's generic.