### PR TITLE
download_ubuntu_packages: Workaround SSL certificate issue on Focal (!)

### DIFF
--- a/download_ubuntu_packages
+++ b/download_ubuntu_packages
@@ -110,16 +110,15 @@ The architecture of the packages is `amd64`; the mirror is http://mirrors.kernel
 If a package is found in the destination path, it's not downloaded.
 "
 
-  params = SimpleScripting::Argv.decode(
+  options = SimpleScripting::Argv.decode(
     ['-d', '--download-to DIRECTORY', "Download directory; defaults to current path."],
     'codename',
     'packages',
     long_help: long_help
   ) || exit
 
-  codename = params[:codename]
-  packages = params[:packages].split(',')
-  options = params.select { |k, _| k == :download_to}
+  codename = options.delete(:codename)
+  packages = options.delete(:packages).split(',')
 
   DownloadUbuntuPackages.new.execute(codename, packages, **options)
 end

--- a/download_ubuntu_packages
+++ b/download_ubuntu_packages
@@ -3,6 +3,7 @@
 require 'open-uri'
 require 'ruby-progressbar'
 require 'uri'
+require 'net/http'
 
 require 'simple_scripting/argv'
 
@@ -36,9 +37,9 @@ class DownloadUbuntuPackages
   ALTERNATE_PACKAGE_SERVER_ADDRESS = "http://security.ubuntu.com"
   DEFAULT_ARCHITECTURE = "amd64"
 
-  def execute(codename, packages, download_to: Dir.pwd)
+  def execute(codename, packages, download_to: Dir.pwd, no_ssl_verification: false)
     packages.each do |package|
-      package_download_page = find_and_open_package_download_page(codename, package)
+      package_download_page = find_and_open_package_download_page(codename, package, no_ssl_verification)
       package_address = find_package_address(package_download_page, package)
       destination_file = compose_destination_file(package_address, download_to)
 
@@ -54,12 +55,14 @@ class DownloadUbuntuPackages
 
   # Tries the default architecture first; if not found, tries the `all`.
   #
-  def find_and_open_package_download_page(codename, package)
+  def find_and_open_package_download_page(codename, package, no_ssl_verification)
+    ssl_verify_mode = no_ssl_verification ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
+
     # If the package has "all" architecture, using the specific architecture address
     # will lead to a page which still has the "all" architecture links.
     #
     package_download_address = download_address(codename, DEFAULT_ARCHITECTURE, package)
-    package_download_page = URI.open(package_download_address).read
+    package_download_page = URI.open(package_download_address, ssl_verify_mode: ssl_verify_mode).read
 
     # Must find a better identifier than `You can download the requested file`.
     #
@@ -108,10 +111,13 @@ if __FILE__ == $PROGRAM_NAME
 The architecture of the packages is `amd64`; the mirror is http://mirrors.kernel.org.
 
 If a package is found in the destination path, it's not downloaded.
+
+The '--no-ssl-verification' is required for a current, unclear issue on Jammy, where opening a package download page (e.g. 'http://packages.ubuntu.com/kinetic/amd64/linux-firmware/download' raises an SSL certificate error).
 "
 
   options = SimpleScripting::Argv.decode(
     ['-d', '--download-to DIRECTORY', "Download directory; defaults to current path."],
+    ['-s', '--no-ssl-verification',   "Disable SSL verification; see help"],
     'codename',
     'packages',
     long_help: long_help

--- a/download_ubuntu_packages
+++ b/download_ubuntu_packages
@@ -7,7 +7,6 @@ require 'uri'
 require 'simple_scripting/argv'
 
 class DownloadWithProgress
-
   def execute(address, destination_file)
     uri = URI(address)
 
@@ -29,11 +28,9 @@ class DownloadWithProgress
       progress_bar.finish
     end
   end
-
 end
 
 class DownloadUbuntuPackages
-
   INDEX_SERVER_ADDRESS = "http://packages.ubuntu.com"
   PACKAGE_SERVER_ADDRESS = "http://de.archive.ubuntu.com"
   ALTERNATE_PACKAGE_SERVER_ADDRESS = "http://security.ubuntu.com"
@@ -99,7 +96,6 @@ class DownloadUbuntuPackages
     file_basename = File.basename(package_address)
     File.join(destination_directory, file_basename)
   end
-
 end
 
 # The server, architecture, and kernel type, all have a default.


### PR DESCRIPTION
Very odd. On Jammy (not on Focal), opening the packages pages raises a certificate error.