### PR TITLE
clean_kernel_packages: Remove orphan headers, and several improvements

### DIFF
--- a/clean_kernel_packages
+++ b/clean_kernel_packages
@@ -4,6 +4,7 @@ require_relative 'kernel_packages_maintenance/kernel_version'
 
 require 'English'
 require 'fileutils'
+require 'set'
 require 'shellwords'
 require 'simple_scripting/argv'
 
@@ -34,7 +35,12 @@ class CleanKernelPackages
       puts "No packages to remove!"
     end
 
-    module_directories_to_remove = find_module_directories_to_remove(delete_current)
+    # WATCH OUT! Converting to set is very important, since Array#include? doesn't use the Hash equality
+    # properties!
+    #
+    kept_image_versions = (installed_image_versions - image_versions_to_remove).to_set
+
+    module_directories_to_remove = find_module_directories_to_remove(kept_image_versions)
     puts "Removing module directories..."
     remove_module_directories(module_directories_to_remove, simulate: simulate)
   end
@@ -112,18 +118,14 @@ class CleanKernelPackages
 
   # Sample of returned directory: `/lib/modules/5.0.2-050002-generic`
   #
-  def find_module_directories_to_remove(delete_current)
+  def find_module_directories_to_remove(kept_image_versions)
     all_module_dirnames = Dir[File.join(MODULES_DIRECTORY, '*')]
+    image_version_strings = kept_image_versions.map(&:to_s).to_set
 
-    if !delete_current
-      all_module_dirnames -= [File.join(MODULES_DIRECTORY, `uname -r`.rstrip)]
+    all_module_dirnames.select do |full_module_dirname|
+      base_module_dirname = File.basename(full_module_dirname)
+      !image_version_strings.include?(base_module_dirname)
     end
-
-    installed_module_dirnames = `aptitude search ~ilinux-image-`
-      .lines
-      .map { |line| File.expand_path(line[/linux-image(-unsigned)?-(\S+)/, 2], MODULES_DIRECTORY) }
-
-    all_module_dirnames - installed_module_dirnames
   end
 
   def remove_packages(packages, simulate:)

--- a/clean_kernel_packages
+++ b/clean_kernel_packages
@@ -9,6 +9,7 @@ require 'simple_scripting/argv'
 
 class CleanKernelPackages
   MODULES_DIRECTORY = '/lib/modules'
+  IMAGE_PACKAGE_PREFIX_REGEX = "^linux-(image|image-unsigned)-"
 
   def execute(simulate: false, keep_previous: false, delete_current: false)
     options = {simulate: simulate, keep_previous: keep_previous, delete_current: delete_current}
@@ -43,14 +44,14 @@ class CleanKernelPackages
   # if there is two packages with/out `-unsigned` are installed for the same version.
   #
   def checked_find_installed_image_versions(current_version)
-    raw_packages_list = find_installed_packages("^linux-(image|image-unsigned)-")
+    raw_packages_list = find_installed_packages(IMAGE_PACKAGE_PREFIX_REGEX)
 
     # version => package name
     #
     package_versions = {}
 
     raw_packages_list.each do |package_name|
-      if package_name =~ /^linux-image(-unsigned)?-(#{current_version.major}\.#{current_version.minor}\.\d+-\w+)/
+      if package_name =~ /#{IMAGE_PACKAGE_PREFIX_REGEX}(#{current_version.major}\.#{current_version.minor}\.\d+-\w+)/
         version = KernelVersion.parse_version($LAST_MATCH_INFO[2])
 
         if package_versions.key?(version)
@@ -65,6 +66,8 @@ class CleanKernelPackages
   end
 
   def find_installed_packages(pattern)
+    # Aptitude doesn't support the `?` metacharacter.
+    #
     `aptitude search -w 120 ~i#{pattern.shellescape} | cut -c 5- | awk '{print $1}'`.split("\n")
   end
 

--- a/clean_kernel_packages
+++ b/clean_kernel_packages
@@ -13,6 +13,7 @@ class CleanKernelPackages
   # Must capture the longer string first, otherwise, `-unsigned` is interpreted as part of the version.
   #
   IMAGE_PACKAGE_PREFIX_REGEX = "^linux-(image-unsigned|image)-"
+  HEADER_PACKAGE_PREFIX_REGEX = "^linux-headers-"
 
   def execute(simulate: false, keep_previous: false, delete_current: false)
     options = {simulate: simulate, keep_previous: keep_previous, delete_current: delete_current}
@@ -39,6 +40,13 @@ class CleanKernelPackages
     # properties!
     #
     kept_image_versions = (installed_image_versions - image_versions_to_remove).to_set
+
+    orphan_header_packages = find_orphan_header_packages(kept_image_versions)
+
+    if orphan_header_packages.size > 0
+      puts "Removing orphan header packages..."
+      remove_packages(orphan_header_packages, simulate: simulate)
+    end
 
     module_directories_to_remove = find_module_directories_to_remove(kept_image_versions)
 
@@ -119,6 +127,24 @@ class CleanKernelPackages
     end.join(' ')
 
     `aptitude search -w 120 #{package_matchers} | cut -c 5- | awk '{print $1}'`.split("\n")
+  end
+
+  def find_orphan_header_packages(kept_image_versions)
+    # A bit tricky, because headers of multiple type have one parent header without the type.
+    # Parent headers are uninstalled automatically when the children are uninstalled, so we don't
+    # need to (directly) take care of them.
+    #
+    all_header_packages = find_installed_packages(HEADER_PACKAGE_PREFIX_REGEX)
+
+    all_header_packages.each_with_object([]) do |package_name, orphan_header_packages|
+      if package_name =~ /#{HEADER_PACKAGE_PREFIX_REGEX}(.+)$/
+        header_version = KernelVersion.parse_version($LAST_MATCH_INFO[1], raise_error: false)
+
+        if header_version && !kept_image_versions.include?(header_version)
+          orphan_header_packages << package_name
+        end
+      end
+    end
   end
 
   # Sample of returned directory: `/lib/modules/5.0.2-050002-generic`

--- a/clean_kernel_packages
+++ b/clean_kernel_packages
@@ -9,7 +9,9 @@ require 'simple_scripting/argv'
 
 class CleanKernelPackages
   MODULES_DIRECTORY = '/lib/modules'
-  IMAGE_PACKAGE_PREFIX_REGEX = "^linux-(image|image-unsigned)-"
+  # Must capture the longer string first, otherwise, `-unsigned` is interpreted as part of the version.
+  #
+  IMAGE_PACKAGE_PREFIX_REGEX = "^linux-(image-unsigned|image)-"
 
   def execute(simulate: false, keep_previous: false, delete_current: false)
     options = {simulate: simulate, keep_previous: keep_previous, delete_current: delete_current}
@@ -51,7 +53,9 @@ class CleanKernelPackages
     package_versions = {}
 
     raw_packages_list.each do |package_name|
-      if package_name =~ /#{IMAGE_PACKAGE_PREFIX_REGEX}(#{current_version.major}\.#{current_version.minor}\.\d+-\w+)/
+      if package_name =~ /#{IMAGE_PACKAGE_PREFIX_REGEX}(.+)$/
+        # The prefix regex captures one group, so we need to skip it.
+        #
         version = KernelVersion.parse_version($LAST_MATCH_INFO[2])
 
         if package_versions.key?(version)

--- a/clean_kernel_packages
+++ b/clean_kernel_packages
@@ -17,16 +17,16 @@ class CleanKernelPackages
 
     puts "Current kernel version: #{current_version}", ""
 
-    installed_versions = checked_find_installed_versions(current_version)
+    installed_image_versions = checked_find_installed_image_versions(current_version)
 
-    puts "Currently installed package versions:", *installed_versions.map { |version| "- #{version}" }, ""
+    puts "Currently installed image package versions:", *installed_image_versions.map { |version| "- #{version}" }, ""
 
-    versions_to_remove = find_versions_to_remove(current_version, installed_versions, **options)
+    image_versions_to_remove = find_image_versions_to_remove(current_version, installed_image_versions, **options)
 
-    if versions_to_remove.size > 0
-      packages_to_remove = find_packages_to_remove(versions_to_remove)
-      puts "Removing packages:", *packages_to_remove.map { |package| "- #{package}"}, ""
-      remove_packages(packages_to_remove, simulate: simulate)
+    if image_versions_to_remove.size > 0
+      kernel_packages_to_remove = find_all_kernel_packages_for_versions(image_versions_to_remove)
+      puts "Removing packages:", *kernel_packages_to_remove.map { |package| "- #{package}"}, ""
+      remove_packages(kernel_packages_to_remove, simulate: simulate)
     else
       puts "No packages to remove!"
     end
@@ -42,7 +42,7 @@ class CleanKernelPackages
   # complicate the script. Not sure if this is a real-world case, but it may happen, for example,
   # if there is two packages with/out `-unsigned` are installed for the same version.
   #
-  def checked_find_installed_versions(current_version)
+  def checked_find_installed_image_versions(current_version)
     raw_packages_list = find_installed_packages("^linux-(image|image-unsigned)-")
 
     # version => package name
@@ -68,12 +68,12 @@ class CleanKernelPackages
     `aptitude search -w 120 ~i#{pattern.shellescape} | cut -c 5- | awk '{print $1}'`.split("\n")
   end
 
-  def find_versions_to_remove(current_version, installed_versions, options = {})
-    future_versions = installed_versions.select do |version|
+  def find_image_versions_to_remove(current_version, installed_image_versions, options = {})
+    future_versions = installed_image_versions.select do |version|
       version > current_version
     end
 
-    previous_versions = installed_versions.select do |version|
+    previous_versions = installed_image_versions.select do |version|
       version < current_version
     end
 
@@ -85,7 +85,7 @@ class CleanKernelPackages
 
     versions_to_delete += future_versions.sort[0..-2] # Keep the latest future
 
-    if versions_to_delete.size == installed_versions.size
+    if versions_to_delete.size == installed_image_versions.size
       message = "No versions remaining after cleaning!"
       options[:simulate] ? puts(message) : raise(message)
     end
@@ -93,7 +93,7 @@ class CleanKernelPackages
     versions_to_delete
   end
 
-  def find_packages_to_remove(versions)
+  def find_all_kernel_packages_for_versions(versions)
     package_matchers = versions.map do |version|
       "~i^linux-(headers|image|image-unsigned|image-extra|modules|modules-extra)-#{version.raw}\\b".shellescape
     end.join(' ')

--- a/clean_kernel_packages
+++ b/clean_kernel_packages
@@ -41,8 +41,13 @@ class CleanKernelPackages
     kept_image_versions = (installed_image_versions - image_versions_to_remove).to_set
 
     module_directories_to_remove = find_module_directories_to_remove(kept_image_versions)
-    puts "Removing module directories..."
-    remove_module_directories(module_directories_to_remove, simulate: simulate)
+
+    if module_directories_to_remove.size > 0
+      puts "Removing module directories..."
+      remove_module_directories(module_directories_to_remove, simulate: simulate)
+    else
+      puts "No module directories to remove!"
+    end
   end
 
   private

--- a/clean_kernel_packages
+++ b/clean_kernel_packages
@@ -63,6 +63,8 @@ class CleanKernelPackages
         else
           package_versions[version] = package_name
         end
+      else
+        raise "Unexpected package name: #{package_name}"
       end
     end
 

--- a/kernel_packages_maintenance/kernel_version.rb
+++ b/kernel_packages_maintenance/kernel_version.rb
@@ -17,6 +17,8 @@ class KernelVersion
   attr_accessor :rc
   attr_accessor :ongoing
 
+  ONGOING_MAX_CHARS = 6
+
   def initialize(raw, major, minor, patch, rc: nil, ongoing: nil)
     @raw = raw
     @major = major.to_i
@@ -32,7 +34,7 @@ class KernelVersion
   # release candidates, or 129 ongoing releases.
   #
   def to_i
-    value = major * 2**24 + minor * 2**16 + patch * 2**8
+    value = (major * 2**24 + minor * 2**16 + patch * 2**8) * 10**ONGOING_MAX_CHARS
 
     # Make ongoing releases higher than all the RC versions, eg 4.10.0 > 4.10.0-rc8.
     #

--- a/kernel_packages_maintenance/kernel_version.rb
+++ b/kernel_packages_maintenance/kernel_version.rb
@@ -89,9 +89,14 @@ class KernelVersion
   end
 
   # version_str format: see class comment
+  # raise_error:        (true) if true, on unidentified version, raise error, otherwise, return nil
   #
-  def self.parse_version(version_str)
-    version_match = version_str.match(VERSION_REGEX) || raise("Unidentified version: #{version_str}")
+  def self.parse_version(version_str, raise_error: true)
+    version_match = version_str.match(VERSION_REGEX)
+
+    if version_match.nil?
+      raise_error ? raise("Unidentified version: #{version_str}") : return
+    end
 
     major, minor, patch, _, ongoing, raw_rc, type = version_match.captures
 

--- a/kernel_packages_maintenance/kernel_version.rb
+++ b/kernel_packages_maintenance/kernel_version.rb
@@ -78,14 +78,7 @@ class KernelVersion
   end
 
   def to_s
-    buffer = "#{major}.#{minor}.#{patch}"
-
-    buffer << "-#{ongoing}" if ongoing
-    buffer << "rc#{rc}" if rc
-
-    buffer << "-#{type}"
-
-    buffer
+    raw
   end
 
   def self.find_current


### PR DESCRIPTION
Now, orphan headers are removed.

There are also many other refactoring and improvements, also semantic (e.g. WRT supported version formats).