### PR TITLE
git_find_default_branch: Fix noise when running remote set-head

### DIFF
--- a/git_find_default_branch
+++ b/git_find_default_branch
@@ -38,7 +38,7 @@ function decode_cmdline_args {
 
 function main {
   if ! git branch --remotes | grep -qP "^\s+$c_remote/HEAD "; then
-    git remote set-head "$c_remote" -a
+    git remote set-head "$c_remote" -a > /dev/null # ignore noise
   fi
 
   git rev-parse --abbrev-ref "$c_remote/HEAD" | perl -ne "print /$c_remote\/(\w+)/"


### PR DESCRIPTION
It's important not to produce noise, since the output of this script may be used programmatically.