### PR TITLE
build_kernel: Merge functionality for with/out kernel version option (and various improvements)

### DIFF
--- a/build_kernel
+++ b/build_kernel
@@ -7,7 +7,7 @@ set -o errtrace
 shopt -s inherit_errexit
 
 c_default_local_version=custom
-c_help="Usage: $(basename "$0") [-h|--help] [-n|--new-kernel-version <version>] [-i|--install] [-r|--repo-path <path>] [-l|--local-version <name>] [packages_destination]
+c_help="Usage: $(basename "$0") [-h|--help] [-v|--kernel-version <version>] [-i|--install] [-r|--repo-path <path>] [-l|--local-version <name>] [packages_destination]
 
 Builds a kernel from the source code:
 
@@ -25,7 +25,7 @@ Params:
 - '--local-version' is the kernel local version (name suffix), it defaults to (\$BUILD_KERNEL_LOCAL_VERSION or '$c_default_local_version'); the minus is automatically added
 - 'packages_destination' must be specified, either explicitly or via \$BUILD_KERNEL_PACKAGES_DESTINATION env variable."
 
-v_new_kernel_version=
+v_kernel_version=
 v_install=              # boolean; false=blank; true=anything else
 v_packages_destination=${BUILD_KERNEL_PACKAGES_DESTINATION:-}
 v_repo_path=${BUILD_KERNEL_REPO_PATH:-}
@@ -33,7 +33,7 @@ v_local_version=${BUILD_KERNEL_LOCAL_VERSION:-}
 
 function decode_cmdline_args {
   local params
-  params=$(getopt --options hn:ir:l: --long help,new-kernel-version:,install,repo-path:,local-version: --name "$(basename "$0")" -- "$@")
+  params=$(getopt --options hv:ir:l: --long help,kernel-version:,install,repo-path:,local-version: --name "$(basename "$0")" -- "$@")
 
   eval set -- "$params"
 
@@ -42,8 +42,8 @@ function decode_cmdline_args {
       -h|--help)
         echo "$c_help"
         exit 0 ;;
-      -n|--new-kernel-version)
-        v_new_kernel_version=$2
+      -v|--kernel-version)
+        v_kernel_version=$2
         shift 2 ;;
       -i|--install)
         v_install=1
@@ -85,7 +85,7 @@ function cache_sudo {
 
 # Return format: M.m.p
 #
-function checked_find_current_version {
+function check_find_current_branch_kernel_version {
   local current_branch
   current_branch=$(git rev-parse --abbrev-ref HEAD | perl -pe "chomp if eof")
 
@@ -103,7 +103,7 @@ function fetch_repo {
 
 # Return format: `M.m.p` or `M.m-rcNN`.
 #
-function find_latest_version {
+function find_latest_kernel_version {
   local full_version=$1
 
   local short_version=${full_version%.*}
@@ -123,9 +123,9 @@ function find_latest_version {
 }
 
 function create_and_switch_branch {
-  local latest_version=$1
+  local latest_kernel_version=$1
 
-  git checkout -b {b,}v"$latest_version"
+  git checkout -b {b,}v"$latest_kernel_version"
 }
 
 function import_config {
@@ -197,9 +197,9 @@ function move_packages_and_cleanup {
 }
 
 function install_kernel_packages {
-  local latest_version=$1
+  local latest_kernel_version=$1
 
-  sudo dpkg -i "$v_packages_destination"/linux-*-"$latest_version"-*.deb
+  sudo dpkg -i "$v_packages_destination"/linux-*-"$latest_kernel_version"-*.deb
 }
 
 function main {
@@ -211,51 +211,51 @@ function main {
     cd "$v_repo_path"
   fi
 
-  # Format: `M.m.p`; `latest_version` can also be `M.m-rcNN`.
+  # Format: `M.m.p`; `latest_kernel_version` can also be `M.m-rcNN`.
   #
-  local current_version latest_version
+  local current_kernel_version latest_kernel_version
 
-  if [[ -n $v_new_kernel_version ]]; then
-    current_version=$v_new_kernel_version
-    latest_version=$v_new_kernel_version
+  if [[ -n $v_kernel_version ]]; then
+    current_kernel_version=$v_kernel_version
+    latest_kernel_version=$v_kernel_version
     fetch_repo
   else
-    current_version=$(checked_find_current_version)
+    current_kernel_version=$(check_find_current_branch_kernel_version)
     fetch_repo
-    latest_version=$(find_latest_version "$current_version")
+    latest_kernel_version=$(find_latest_kernel_version "$current_kernel_version")
 
-    if [[ $current_version == "$latest_version" ]]; then
-      echo "No new version! Current:$current_version, latest:$latest_version"
+    if [[ $current_kernel_version == "$latest_kernel_version" ]]; then
+      echo "No new version! Current:$current_kernel_version, latest:$latest_kernel_version"
       exit 0
     fi
   fi
 
-  create_and_switch_branch "$latest_version"
+  create_and_switch_branch "$latest_kernel_version"
 
-  import_config "$current_version"
+  import_config "$current_kernel_version"
 
   # Always patch for simplicity, so if we want to replace the config for a version with an existing
   # configuration, we don't need to manually patch it.
   #
   patch_config
 
-  if [[ -z $v_new_kernel_version ]]; then
+  if [[ -z $v_kernel_version ]]; then
     update_config
-    check_config_diff "$current_version"
+    check_config_diff "$current_kernel_version"
   fi
 
   compile_kernel
 
-  if [[ -z $v_new_kernel_version ]]; then
-    remove_destination_old_version_files "$current_version"
+  if [[ -z $v_kernel_version ]]; then
+    remove_destination_old_version_files "$current_kernel_version"
   fi
 
-  export_config "$latest_version"
+  export_config "$latest_kernel_version"
 
   move_packages_and_cleanup
 
   if [[ -n $v_install ]]; then
-    install_kernel_packages "$latest_version"
+    install_kernel_packages "$latest_kernel_version"
   fi
 }
 

--- a/build_kernel
+++ b/build_kernel
@@ -23,7 +23,11 @@ Params:
 
 - '--repo-path' defaults to (current path or \$BUILD_KERNEL_REPO_PATH env variable)
 - '--local-version' is the kernel local version (name suffix), it defaults to (\$BUILD_KERNEL_LOCAL_VERSION or '$c_default_local_version'); the minus is automatically added
-- 'packages_destination' must be specified, either explicitly or via \$BUILD_KERNEL_PACKAGES_DESTINATION env variable."
+- 'packages_destination' must be specified, either explicitly or via \$BUILD_KERNEL_PACKAGES_DESTINATION env variable.
+
+Notes:
+
+- RC versions are not supported (anymore)"
 
 v_kernel_version=
 v_install=              # boolean; false=blank; true=anything else
@@ -101,7 +105,7 @@ function fetch_repo {
   git fetch
 }
 
-# Return format: `M.m.p` or `M.m-rcNN`.
+# Return format: `M.m.p`.
 #
 function find_latest_kernel_version {
   local full_version=$1
@@ -109,17 +113,11 @@ function find_latest_kernel_version {
   local short_version=${full_version%.*}
   local escaped_short_version=${short_version//./\\.}
 
-  local rc_versions
-  # There has been one case of double-digit RC! Better safe than sorry regardless.
-  rc_versions=$(git tag | grep -P "^v$escaped_short_version.+rc\d+$")
-
-  local release_versions
-  release_versions=$(git tag | grep -P "^v$escaped_short_version" | grep -v rc || true)
-
-  (
-    echo -n "$rc_versions" | sort -V
-    echo -n "$release_versions" | sort -V
-  ) | tail -n 1 | perl -pe 's/^v//'
+  git tag |
+    grep -P "^v$escaped_short_version" |
+    sort -V |
+    tail -n 1 |
+    perl -pe 's/^v//'
 }
 
 function create_and_switch_branch {
@@ -211,7 +209,7 @@ function main {
     cd "$v_repo_path"
   fi
 
-  # Format: `M.m.p`; `latest_kernel_version` can also be `M.m-rcNN`.
+  # Format: `M.m.p`.
   #
   local current_kernel_version latest_kernel_version
 

--- a/build_kernel
+++ b/build_kernel
@@ -11,8 +11,7 @@ c_help="Usage: $(basename "$0") [-h|--help] [-n|--new-kernel-version <version>] 
 
 Builds a kernel from the source code:
 
-- fetches the repository and finds the latest patch version (for the current branch version)
-  - if --new-kernel-version is specified, it's used as current version
+- fetches the repository and finds the latest patch version (for the current branch version, or the specified one)
 - copies the corresponding configuration from the <packages_destination>
 - updates the configuration
 - patches the configuration to make it compile (assumes it's Ubuntu)
@@ -25,7 +24,6 @@ Params:
 - '--repo-path' defaults to (current path or \$BUILD_KERNEL_REPO_PATH env variable)
 - '--local-version' is the kernel local version (name suffix), it defaults to (\$BUILD_KERNEL_LOCAL_VERSION or '$c_default_local_version'); the minus is automatically added
 - 'packages_destination' must be specified, either explicitly or via \$BUILD_KERNEL_PACKAGES_DESTINATION env variable."
-
 
 v_new_kernel_version=
 v_install=              # boolean; false=blank; true=anything else
@@ -103,8 +101,11 @@ function fetch_repo {
   git fetch
 }
 
+# Return format: `M.m.p` or `M.m-rcNN`.
+#
 function find_latest_version {
   local full_version=$1
+
   local short_version=${full_version%.*}
   local escaped_short_version=${short_version//./\\.}
 
@@ -210,7 +211,10 @@ function main {
     cd "$v_repo_path"
   fi
 
+  # Format: `M.m.p`; `latest_version` can also be `M.m-rcNN`.
+  #
   local current_version latest_version
+
   if [[ -n $v_new_kernel_version ]]; then
     current_version=$v_new_kernel_version
     latest_version=$v_new_kernel_version

--- a/build_kernel
+++ b/build_kernel
@@ -140,10 +140,16 @@ function find_latest_packaged_version {
     true
 }
 
-function create_and_switch_branch {
+function create_if_required_and_switch_branch {
   local latest_kernel_version=$1
 
-  git checkout -b {b,}v"$latest_kernel_version"
+  local branch_working_copy=bv"$latest_kernel_version"
+
+  if git rev-parse --verify "$branch_working_copy" 2> /dev/null; then
+    git checkout "$branch_working_copy"
+  else
+    git checkout -b "$branch_working_copy" v"$latest_kernel_version"
+  fi
 }
 
 function import_latest_config {
@@ -262,7 +268,7 @@ function main {
     fi
   fi
 
-  create_and_switch_branch "$latest_kernel_version"
+  create_if_required_and_switch_branch "$latest_kernel_version"
 
   import_latest_config "$current_kernel_version"
 

--- a/build_kernel
+++ b/build_kernel
@@ -136,6 +136,10 @@ function import_config {
   cp "$config_backup" .config
 }
 
+function backup_config {
+  cp .config{,.bak}
+}
+
 function patch_config {
   scripts/config --set-str SYSTEM_TRUSTED_KEYS ""
   scripts/config --set-str SYSTEM_REVOCATION_KEYS ""
@@ -154,14 +158,10 @@ function update_config {
 }
 
 function check_config_diff {
-  local version=$1
-
-  local config_backup=$v_packages_destination/config-$version
-
   # Assume that the error status 2 (real error) can't happen, because the file exists.
   #
-  if ! diff "$config_backup" .config > /dev/null; then
-    meld "$config_backup" .config
+  if ! diff .config{.bak,} > /dev/null; then
+    meld .config{.bak,}
   fi
 }
 
@@ -234,6 +234,8 @@ function main {
 
   import_config "$current_kernel_version"
 
+  backup_config
+
   # Always patch for simplicity, so if we want to replace the config for a version with an existing
   # configuration, we don't need to manually patch it.
   #
@@ -241,7 +243,7 @@ function main {
 
   if [[ -z $v_kernel_version ]]; then
     update_config
-    check_config_diff "$current_kernel_version"
+    check_config_diff
   fi
 
   compile_kernel

--- a/build_kernel
+++ b/build_kernel
@@ -12,7 +12,7 @@ c_help="Usage: $(basename "$0") [-h|--help] [-v|--kernel-version <version>] [-i|
 Builds a kernel from the source code:
 
 - fetches the repository and finds the latest patch version (for the current branch version, or the specified one)
-- copies the corresponding configuration from the <packages_destination>
+- copies the latest version of the configuration for the current kernel, in <packages_destination>
 - updates the configuration
 - patches the configuration to make it compile (assumes it's Ubuntu)
 - copies the configuration to <packages_destination>
@@ -126,12 +126,24 @@ function create_and_switch_branch {
   git checkout -b {b,}v"$latest_kernel_version"
 }
 
-function import_config {
-  local version=$1
+function import_latest_config {
+  # Accepts full/short versions.
+  #
+  local raw_version=$1
 
-  local config_backup=$v_packages_destination/config-$version
+  local short_version
+  short_version=$(echo "$raw_version" | perl -ne 'print /(\d+\.\d+)/')
 
-  cp "$config_backup" .config
+  # The match need to be precise; ignore other configurations (with suffixes) that may be present.
+
+  local latest_config
+  latest_config_file=$(
+    find "$v_packages_destination" -regextype egrep -regex ".*/config-$short_version.[[:digit:]]+" |
+      sort -V |
+      tail -n 1
+  )
+
+  cp "$latest_config_file" .config
 }
 
 function backup_config {
@@ -230,7 +242,7 @@ function main {
 
   create_and_switch_branch "$latest_kernel_version"
 
-  import_config "$current_kernel_version"
+  import_latest_config "$current_kernel_version"
 
   backup_config
 

--- a/build_kernel
+++ b/build_kernel
@@ -120,6 +120,26 @@ function find_latest_kernel_version {
     perl -pe 's/^v//'
 }
 
+# Assumes that there are no multiple builds for the same version.
+#
+# Return format: `M.m.p`.
+#
+function find_latest_packaged_version {
+  # Accepts full/short versions.
+  #
+  local raw_version=$1
+
+  local short_version=$(echo "$raw_version" | perl -ne 'print /(\d+\.\d+)/')
+
+  # Use the image package for reference.
+  #
+  find "$v_packages_destination" -regextype egrep -regex ".*/linux-image-$short_version.[[:digit:]]+-.+" -printf "%P\n" |
+    sort -V |
+    tail -n 1 |
+    perl -ne 'print /linux-image-(.*?)-/' ||
+    true
+}
+
 function create_and_switch_branch {
   local latest_kernel_version=$1
 
@@ -233,9 +253,11 @@ function main {
     current_kernel_version=$(check_find_current_branch_kernel_version)
     fetch_repo
     latest_kernel_version=$(find_latest_kernel_version "$current_kernel_version")
+    local latest_packaged_version
+    latest_packaged_version=$(find_latest_packaged_version "$current_kernel_version")
 
-    if [[ $current_kernel_version == "$latest_kernel_version" ]]; then
-      echo "No new version! Current:$current_kernel_version, latest:$latest_kernel_version"
+    if [[ $latest_kernel_version == "$latest_packaged_version" ]]; then
+      echo "No new version! Latest packaged/availble: $latest_kernel_version"
       exit 0
     fi
   fi

--- a/build_kernel
+++ b/build_kernel
@@ -249,25 +249,24 @@ function main {
     cd "$v_repo_path"
   fi
 
+  # Format: `M.m` or `M.m.p`.
+  #
+  local current_kernel_version=${v_kernel_version:-"$(checked_find_current_kernel_version)"}
+
+  fetch_repo
+
   # Format: `M.m.p`.
   #
-  local current_kernel_version latest_kernel_version
+  local latest_kernel_version=$(find_latest_kernel_version "$current_kernel_version")
 
-  if [[ -n $v_kernel_version ]]; then
-    current_kernel_version=$v_kernel_version
-    latest_kernel_version=$v_kernel_version
-    fetch_repo
-  else
-    current_kernel_version=$(check_find_current_branch_kernel_version)
-    fetch_repo
-    latest_kernel_version=$(find_latest_kernel_version "$current_kernel_version")
-    local latest_packaged_version
-    latest_packaged_version=$(find_latest_packaged_version "$current_kernel_version")
+  # Format: `M.m.p`.
+  #
+  local latest_packaged_version
+  latest_packaged_version=$(find_latest_packaged_version "$current_kernel_version")
 
-    if [[ $latest_kernel_version == "$latest_packaged_version" ]]; then
-      echo "No new version! Latest packaged/availble: $latest_kernel_version"
-      exit 0
-    fi
+  if [[ $latest_kernel_version == "$latest_packaged_version" ]]; then
+    echo "No new version! Latest packaged/available: $latest_kernel_version"
+    exit 0
   fi
 
   create_if_required_and_switch_branch "$latest_kernel_version"
@@ -281,16 +280,12 @@ function main {
   #
   patch_config
 
-  if [[ -z $v_kernel_version ]]; then
-    update_config
-    check_config_diff
-  fi
+  update_config
+  check_config_diff
 
   compile_kernel
 
-  if [[ -z $v_kernel_version ]]; then
-    remove_destination_old_version_files "$current_kernel_version"
-  fi
+  remove_destination_old_version_files "$current_kernel_version"
 
   export_config "$latest_kernel_version"
 

--- a/build_kernel
+++ b/build_kernel
@@ -108,9 +108,11 @@ function fetch_repo {
 # Return format: `M.m.p`.
 #
 function find_latest_kernel_version {
-  local full_version=$1
+  local raw_version=$1
 
-  local short_version=${full_version%.*}
+  # Accepts full/short versions.
+  #
+  local short_version=$(echo "$raw_version" | perl -ne 'print /(\d+\.\d+)/')
   local escaped_short_version=${short_version//./\\.}
 
   git tag |


### PR DESCRIPTION
Significant improvements in UX, and nice improvement in the code.

Along with this change, many improvements have been made, most notably:

- Remove support for RC versions
- On config import, find the latest available
- Find and use latest packaged version to decide if building or not
- Don't create the new branch if it exists already